### PR TITLE
Add currency viewer core and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "MultiCurrency-for-macOS",
+    platforms: [.macOS(.v12)],
+    products: [
+        .library(name: "MultiCurrencyCore", targets: ["MultiCurrencyCore"]),
+        .executable(name: "MultiCurrencyApp", targets: ["MultiCurrencyApp"])
+    ],
+    targets: [
+        .target(name: "MultiCurrencyCore"),
+        .executableTarget(
+            name: "MultiCurrencyApp",
+            dependencies: ["MultiCurrencyCore"]
+        ),
+        .testTarget(
+            name: "MultiCurrencyCoreTests",
+            dependencies: ["MultiCurrencyCore"]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # MultiCurrency-for-macOS
+
+This repository contains a sample SwiftUI macOS application showing real time currency rates. The core logic is provided in the `MultiCurrencyCore` package with protocol-based API adapters, persistence using `UserDefaults`, and unit tests.
+
+Run the tests with `swift test`.
+

--- a/Sources/MultiCurrencyApp/SettingsView.swift
+++ b/Sources/MultiCurrencyApp/SettingsView.swift
@@ -1,0 +1,21 @@
+import MultiCurrencyCore
+#if canImport(SwiftUI)
+import SwiftUI
+
+struct SettingsView: View {
+    @AppStorage("selectedProvider") private var provider: String = PersistenceManager.shared.selectedProviderIdentifier ?? "ExchangeRateAPI"
+
+    var body: some View {
+        Form {
+            Picker("API Provider", selection: $provider) {
+                Text("ExchangeRate-API").tag("ExchangeRateAPI")
+                Text("OpenExchangeAPI").tag("OpenExchangeAPI")
+            }
+        }
+        .onChange(of: provider) { newValue in
+            PersistenceManager.shared.selectedProviderIdentifier = newValue
+        }
+        .navigationTitle("Settings")
+    }
+}
+#endif

--- a/Sources/MultiCurrencyApp/main.swift
+++ b/Sources/MultiCurrencyApp/main.swift
@@ -1,0 +1,70 @@
+import MultiCurrencyCore
+#if canImport(SwiftUI)
+import SwiftUI
+
+@main
+struct MultiCurrencyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+
+struct ContentView: View {
+    @State private var amountText: String = "1"
+    @State private var rates: CurrencyRates?
+    @State private var lastUpdated: Date?
+
+    private let fetcher: CurrencyRateFetcher
+
+    init() {
+        let primary = ExchangeRateAPIService(apiKey: "YOUR_API_KEY")
+        let fallback = OpenExchangeAPIService(apiKey: "YOUR_API_KEY")
+        fetcher = CurrencyRateFetcher(primary: primary, fallbacks: [fallback])
+    }
+
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading) {
+                TextField("Amount", text: $amountText)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .onChange(of: amountText) { _ in Task { await load() } }
+                    .padding()
+
+                if let rates {
+                    List(rates.rates.sorted(by: { $0.key < $1.key }), id: \.key) { code, rate in
+                        HStack {
+                            Text(code)
+                            Spacer()
+                            Text(String(format: "%.2f", rate * (ExpressionParser.evaluate(amountText) ?? 1)))
+                        }
+                    }
+                } else {
+                    Text("No data")
+                }
+
+                if let lastUpdated {
+                    Text("Last updated: \(lastUpdated.formatted(date: .abbreviated, time: .standard))")
+                        .font(.footnote)
+                        .padding()
+                }
+            }
+            .navigationTitle("Rates")
+            .toolbar {
+                NavigationLink("Settings") {
+                    SettingsView()
+                }
+            }
+            .task { await load() }
+        }
+    }
+
+    private func load() async {
+        if let fetched = await fetcher.fetchRates(base: "USD") {
+            rates = fetched
+            lastUpdated = fetched.lastUpdated
+        }
+    }
+}
+#endif

--- a/Sources/MultiCurrencyCore/CurrencyAPIService.swift
+++ b/Sources/MultiCurrencyCore/CurrencyAPIService.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Abstraction for a currency API.
+public protocol CurrencyAPIService {
+    /// Unique identifier for the service.
+    var identifier: String { get }
+
+    /// Fetches the latest exchange rates.
+    /// - Parameter base: Base currency code (e.g. "USD").
+    /// - Returns: CurrencyRates model.
+    func fetchLatestRates(base: String) async throws -> CurrencyRates
+}
+
+/// Example error type for service failures.
+public enum CurrencyAPIError: Error {
+    case invalidResponse
+    case requestFailed(Error)
+}

--- a/Sources/MultiCurrencyCore/CurrencyRateFetcher.swift
+++ b/Sources/MultiCurrencyCore/CurrencyRateFetcher.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Manages fetching currency rates with fallback providers and caching.
+public final actor CurrencyRateFetcher {
+    private let primary: CurrencyAPIService
+    private let fallbacks: [CurrencyAPIService]
+    private let persistence = PersistenceManager.shared
+
+    public init(primary: CurrencyAPIService, fallbacks: [CurrencyAPIService] = []) {
+        self.primary = primary
+        self.fallbacks = fallbacks
+    }
+
+    /// Fetch latest rates using primary provider, falling back to others on failure.
+    public func fetchRates(base: String) async -> CurrencyRates? {
+        let services = [primary] + fallbacks
+        for service in services {
+            do {
+                let rates = try await service.fetchLatestRates(base: base)
+                persistence.saveCachedRates(rates)
+                return rates
+            } catch {
+                // try next service
+                continue
+            }
+        }
+        // all failed
+        return persistence.loadCachedRates()
+    }
+}

--- a/Sources/MultiCurrencyCore/ExchangeRateAPIService.swift
+++ b/Sources/MultiCurrencyCore/ExchangeRateAPIService.swift
@@ -1,0 +1,33 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Example adapter for the ExchangeRate-API service.
+public final class ExchangeRateAPIService: CurrencyAPIService {
+    public let identifier = "ExchangeRateAPI"
+    private let apiKey: String
+
+    public init(apiKey: String) {
+        self.apiKey = apiKey
+    }
+
+    public func fetchLatestRates(base: String) async throws -> CurrencyRates {
+        let urlStr = "https://v6.exchangerate-api.com/v6/\(apiKey)/latest/\(base)"
+        guard let url = URL(string: urlStr) else {
+            throw CurrencyAPIError.invalidResponse
+        }
+
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let decoded = try JSONDecoder().decode(Response.self, from: data)
+        return CurrencyRates(base: base, rates: decoded.conversionRates, lastUpdated: Date())
+    }
+
+    private struct Response: Decodable {
+        let conversionRates: [String: Double]
+
+        enum CodingKeys: String, CodingKey {
+            case conversionRates = "conversion_rates"
+        }
+    }
+}

--- a/Sources/MultiCurrencyCore/ExpressionParser.swift
+++ b/Sources/MultiCurrencyCore/ExpressionParser.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+public struct ExpressionParser {
+    public static func evaluate(_ expression: String) -> Double? {
+        let trimmed = expression.replacingOccurrences(of: " ", with: "")
+        let allowed = CharacterSet(charactersIn: "0123456789+-*/().")
+        guard trimmed.unicodeScalars.allSatisfy({ allowed.contains($0) }) else { return nil }
+        guard let tokens = tokenize(trimmed) else { return nil }
+        guard let rpn = toRPN(tokens) else { return nil }
+        return evaluateRPN(rpn)
+    }
+
+    private enum Token {
+        case number(Double)
+        case oper(Character)
+        case lparen
+        case rparen
+    }
+
+    private static func tokenize(_ str: String) -> [Token]? {
+        var tokens: [Token] = []
+        var number = ""
+        for c in str {
+            if c.isNumber || c == "." {
+                number.append(c)
+            } else {
+                if !number.isEmpty {
+                    if let d = Double(number) { tokens.append(.number(d)) } else { return nil }
+                    number = ""
+                }
+                switch c {
+                case "+", "-", "*", "/": tokens.append(.oper(c))
+                case "(": tokens.append(.lparen)
+                case ")": tokens.append(.rparen)
+                default: return nil
+                }
+            }
+        }
+        if !number.isEmpty { if let d = Double(number) { tokens.append(.number(d)) } else { return nil } }
+        return tokens
+    }
+
+    private static func precedence(_ op: Character) -> Int {
+        switch op {
+        case "+", "-": return 1
+        case "*", "/": return 2
+        default: return 0
+        }
+    }
+
+    private static func toRPN(_ tokens: [Token]) -> [Token]? {
+        var output: [Token] = []
+        var stack: [Character] = []
+        for token in tokens {
+            switch token {
+            case .number:
+                output.append(token)
+            case .oper(let op):
+                while let last = stack.last, precedence(last) >= precedence(op) {
+                    output.append(.oper(stack.removeLast()))
+                }
+                stack.append(op)
+            case .lparen:
+                stack.append("(")
+            case .rparen:
+                while let last = stack.last, last != "(" {
+                    output.append(.oper(stack.removeLast()))
+                }
+                if stack.last == "(" { stack.removeLast() } else { return nil }
+            }
+        }
+        while let last = stack.popLast() {
+            if last == "(" { return nil }
+            output.append(.oper(last))
+        }
+        return output
+    }
+
+    private static func evaluateRPN(_ tokens: [Token]) -> Double? {
+        var stack: [Double] = []
+        for token in tokens {
+            switch token {
+            case .number(let v):
+                stack.append(v)
+            case .oper(let op):
+                guard stack.count >= 2 else { return nil }
+                let rhs = stack.removeLast()
+                let lhs = stack.removeLast()
+                switch op {
+                case "+": stack.append(lhs + rhs)
+                case "-": stack.append(lhs - rhs)
+                case "*": stack.append(lhs * rhs)
+                case "/": stack.append(lhs / rhs)
+                default: return nil
+                }
+            default:
+                return nil
+            }
+        }
+        return stack.count == 1 ? stack[0] : nil
+    }
+}

--- a/Sources/MultiCurrencyCore/Models.swift
+++ b/Sources/MultiCurrencyCore/Models.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Represents exchange rates relative to a base currency.
+public struct CurrencyRates: Codable {
+    /// Base currency code (e.g. "USD")
+    public let base: String
+    /// Map of currency codes to rates.
+    public let rates: [String: Double]
+    /// Timestamp for last update.
+    public let lastUpdated: Date
+}

--- a/Sources/MultiCurrencyCore/OpenExchangeAPIService.swift
+++ b/Sources/MultiCurrencyCore/OpenExchangeAPIService.swift
@@ -1,0 +1,28 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Example fallback adapter using a hypothetical API structure similar to openexchangerates.org
+public final class OpenExchangeAPIService: CurrencyAPIService {
+    public let identifier = "OpenExchangeAPI"
+    private let apiKey: String
+
+    public init(apiKey: String) {
+        self.apiKey = apiKey
+    }
+
+    public func fetchLatestRates(base: String) async throws -> CurrencyRates {
+        let urlStr = "https://openexchangerates.org/api/latest.json?app_id=\(apiKey)&base=\(base)"
+        guard let url = URL(string: urlStr) else {
+            throw CurrencyAPIError.invalidResponse
+        }
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let decoded = try JSONDecoder().decode(Response.self, from: data)
+        return CurrencyRates(base: base, rates: decoded.rates, lastUpdated: Date())
+    }
+
+    private struct Response: Decodable {
+        let rates: [String: Double]
+    }
+}

--- a/Sources/MultiCurrencyCore/PersistenceManager.swift
+++ b/Sources/MultiCurrencyCore/PersistenceManager.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Manages persistence using UserDefaults.
+public final class PersistenceManager {
+    public static let shared = PersistenceManager()
+
+    private let favoritesKey = "favorites"
+    private let providerKey = "selectedProvider"
+    private let cachedRatesKey = "cachedRates"
+
+    private var defaults: UserDefaults { .standard }
+
+    private init() {}
+
+    // MARK: Favorites
+
+    public var favoriteCurrencies: [String] {
+        get { defaults.stringArray(forKey: favoritesKey) ?? [] }
+        set { defaults.set(newValue, forKey: favoritesKey) }
+    }
+
+    // MARK: Selected Provider
+
+    public var selectedProviderIdentifier: String? {
+        get { defaults.string(forKey: providerKey) }
+        set { defaults.set(newValue, forKey: providerKey) }
+    }
+
+    // MARK: Cached Rates
+
+    public func saveCachedRates(_ rates: CurrencyRates) {
+        if let data = try? JSONEncoder().encode(rates) {
+            defaults.set(data, forKey: cachedRatesKey)
+        }
+    }
+
+    public func loadCachedRates() -> CurrencyRates? {
+        guard let data = defaults.data(forKey: cachedRatesKey),
+              let rates = try? JSONDecoder().decode(CurrencyRates.self, from: data) else {
+            return nil
+        }
+        return rates
+    }
+}

--- a/Tests/MultiCurrencyCoreTests/CurrencyRateFetcherTests.swift
+++ b/Tests/MultiCurrencyCoreTests/CurrencyRateFetcherTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import MultiCurrencyCore
+
+final class CurrencyRateFetcherTests: XCTestCase {
+    func testFallbackMechanism() async {
+        let failureService = MockAPIService(identifier: "primary", result: .failure(CurrencyAPIError.invalidResponse))
+        let successRates = CurrencyRates(base: "USD", rates: ["EUR": 0.9], lastUpdated: Date())
+        let successService = MockAPIService(identifier: "fallback", result: .success(successRates))
+        let fetcher = CurrencyRateFetcher(primary: failureService, fallbacks: [successService])
+        let rates = await fetcher.fetchRates(base: "USD")
+        XCTAssertEqual(rates?.rates["EUR"], 0.9)
+    }
+
+    func testCacheUsedOnFailure() async {
+        let cached = CurrencyRates(base: "USD", rates: ["JPY": 150], lastUpdated: Date())
+        PersistenceManager.shared.saveCachedRates(cached)
+        let failureService = MockAPIService(identifier: "primary", result: .failure(CurrencyAPIError.invalidResponse))
+        let fetcher = CurrencyRateFetcher(primary: failureService)
+        let rates = await fetcher.fetchRates(base: "USD")
+        XCTAssertEqual(rates?.rates["JPY"], 150)
+    }
+}

--- a/Tests/MultiCurrencyCoreTests/ExpressionParserTests.swift
+++ b/Tests/MultiCurrencyCoreTests/ExpressionParserTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import MultiCurrencyCore
+
+final class ExpressionParserTests: XCTestCase {
+    func testValidExpression() {
+        XCTAssertEqual(ExpressionParser.evaluate("5*3+10"), 25)
+        XCTAssertEqual(ExpressionParser.evaluate("2 + 2 * 2"), 6)
+    }
+
+    func testInvalidExpression() {
+        XCTAssertNil(ExpressionParser.evaluate("5**"))
+        XCTAssertNil(ExpressionParser.evaluate("abc"))
+    }
+}

--- a/Tests/MultiCurrencyCoreTests/MockAPIService.swift
+++ b/Tests/MultiCurrencyCoreTests/MockAPIService.swift
@@ -1,0 +1,16 @@
+import Foundation
+@testable import MultiCurrencyCore
+
+struct MockAPIService: CurrencyAPIService {
+    let identifier: String
+    var result: Result<CurrencyRates, Error>
+
+    func fetchLatestRates(base: String) async throws -> CurrencyRates {
+        switch result {
+        case .success(let rates):
+            return rates
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/Tests/MultiCurrencyCoreTests/MockAPIServiceTests.swift
+++ b/Tests/MultiCurrencyCoreTests/MockAPIServiceTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import MultiCurrencyCore
+
+final class MockAPIServiceTests: XCTestCase {
+    func testSuccess() async throws {
+        let rates = CurrencyRates(base: "USD", rates: ["EUR": 1.0], lastUpdated: Date())
+        let api = MockAPIService(identifier: "mock", result: .success(rates))
+        let fetched = try await api.fetchLatestRates(base: "USD")
+        XCTAssertEqual(fetched.rates["EUR"], 1.0)
+    }
+
+    func testFailure() async {
+        let api = MockAPIService(identifier: "mock", result: .failure(CurrencyAPIError.invalidResponse))
+        do {
+            _ = try await api.fetchLatestRates(base: "USD")
+            XCTFail("Expected failure")
+        } catch {
+            // success
+        }
+    }
+}

--- a/Tests/MultiCurrencyCoreTests/PersistenceManagerTests.swift
+++ b/Tests/MultiCurrencyCoreTests/PersistenceManagerTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import MultiCurrencyCore
+
+final class PersistenceManagerTests: XCTestCase {
+    func testSaveAndLoadFavorites() {
+        let pm = PersistenceManager.shared
+        pm.favoriteCurrencies = ["USD", "EUR"]
+        XCTAssertEqual(pm.favoriteCurrencies, ["USD", "EUR"])
+    }
+
+    func testSaveAndLoadProvider() {
+        let pm = PersistenceManager.shared
+        pm.selectedProviderIdentifier = "ExchangeRateAPI"
+        XCTAssertEqual(pm.selectedProviderIdentifier, "ExchangeRateAPI")
+    }
+
+    func testSaveAndLoadCachedRates() {
+        let pm = PersistenceManager.shared
+        let rates = CurrencyRates(base: "USD", rates: ["GBP": 0.8], lastUpdated: Date())
+        pm.saveCachedRates(rates)
+        XCTAssertEqual(pm.loadCachedRates()?.rates["GBP"], 0.8)
+    }
+}


### PR DESCRIPTION
## Summary
- initialize Swift package with macOS app target and core library
- implement `CurrencyAPIService` protocol and two API adapters
- add `CurrencyRateFetcher` with fallback logic
- implement arithmetic `ExpressionParser`
- create SwiftUI `ContentView` and `SettingsView`
- manage persistence with `UserDefaults`
- provide comprehensive unit tests for parser, fetcher and persistence
- update README

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_684124ce35088332afc98d9a7e77994e